### PR TITLE
Cookies! 

### DIFF
--- a/lib/splunk/pickaxe.rb
+++ b/lib/splunk/pickaxe.rb
@@ -4,6 +4,7 @@ require 'splunk-sdk-ruby'
 require 'uri'
 require 'splunk/pickaxe/config'
 require 'splunk/pickaxe/client'
+require 'splunk/pickaxe/cookie_proxy'
 
 module Splunk
   module Pickaxe
@@ -16,6 +17,7 @@ module Splunk
 
       puts "Connecting to splunk [#{uri}]"
       service = Splunk.connect(
+        proxy: CookieProxy,
         scheme: uri.scheme.to_sym,
         host: uri.host,
         port: uri.port,

--- a/lib/splunk/pickaxe/cookie_proxy.rb
+++ b/lib/splunk/pickaxe/cookie_proxy.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Splunk
+  module Pickaxe
+    class CookieProxy < Net::HTTP
+      @@cookies ||= nil
+
+      def request(req, body = nil, &block)  # :yield: +response+
+        if @@cookies 
+          req['Cookie'] = @@cookies
+        end
+        r = super(req,body,&block)
+        c = r.to_hash['set-cookie']
+        if c 
+          @@cookies = c.collect{|ea|ea[/^.*?;/]}.join
+        end
+        return r
+      end
+    end
+  end
+end

--- a/lib/splunk/pickaxe/objects.rb
+++ b/lib/splunk/pickaxe/objects.rb
@@ -89,6 +89,9 @@ module Splunk
       def save
         puts "Saving all #{entity_dir.capitalize}"
 
+        dir = File.join(pickaxe_config.execution_path, entity_dir)
+        Dir.mkdir dir unless Dir.exist? dir
+
         Splunk::Collection.new(service, splunk_resource)
                           .map { |e| save_config e }
       end

--- a/spec/objects_spec.rb
+++ b/spec/objects_spec.rb
@@ -175,6 +175,8 @@ describe Splunk::Pickaxe::Objects do
     let(:splunk_entity2) { double 'splunk_entity2' }
 
     before do
+      entity_dir = File.join(execution_path, 'my-dir')
+      allow(Dir).to receive(:exist?).with(entity_dir).and_return(true)
       allow(Splunk::Collection).to receive(:new).with(service, ['resource'])
                                                 .and_return(splunk_collection)
       allow(splunk_collection).to receive(:map).and_yield(splunk_entity1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,8 @@ require 'splunk/pickaxe/cli'
 
 def splunk_object_classes
   constants = Splunk::Pickaxe.constants.select {|c| Splunk::Pickaxe.const_get(c).is_a? Class}
-  # This needs to remove any other classes that are included in Pickaxe namespace
-  constants = constants - [:Config, :Objects, :Client, :CLI]
-  constants.map{ |c| Splunk::Pickaxe.const_get(c) }
+  constants = constants.map{ |c| Splunk::Pickaxe.const_get(c) }
+
+  # This removes any other classes that are included in Pickaxe namespace
+  constants.select { |c| c < Splunk::Pickaxe::Objects }
 end


### PR DESCRIPTION
The problem with load balancing an API port, is there is no session to go by. So when a load balancer injects a cookie to keep track of which backend the previous request went to, we need to pick up and provide the same cookie to subsequent requests. 

Unfortunately, the upstream Splunk Ruby SDK is dead, but fortunately, they provided a way for us to provide a wrapper proxy around Net:HTTP.

The method of parsing the set-cookie header comes from: https://stackoverflow.com/a/10545462/504685

Also featuring in this pull request:
* Fixing the Spec Helper to use inheritance to keep only the Splunk object classes
* Creating directories on demand with save (can you tell how I was testing cookies without being destructive? :) ) 

Not featured: 
* Tests... Because I'm a lazy bum and not good enough at Ruby
* Sir Not-Appearing-In-This-Film.