### PR TITLE
--overwrite command for pickaxe save

### DIFF
--- a/lib/splunk/pickaxe.rb
+++ b/lib/splunk/pickaxe.rb
@@ -7,8 +7,8 @@ require 'splunk/pickaxe/client'
 
 module Splunk
   module Pickaxe
-    def self.configure(environment, username, password, execution_path = Dir.getwd)
-      config = Config.load execution_path
+    def self.configure(environment, username, password, args)
+      config = Config.load(args.fetch(:repo_path, Dir.getwd))
 
       raise "Unknown environment [#{environment}]. Expected #{config.environments.keys}" unless config.environments.key?(environment)
 
@@ -24,7 +24,7 @@ module Splunk
         namespace: config.namespace
       )
 
-      Client.new service, environment.downcase, config
+      Client.new service, environment.downcase, config, args
     end
   end
 end

--- a/lib/splunk/pickaxe/cli.rb
+++ b/lib/splunk/pickaxe/cli.rb
@@ -49,7 +49,6 @@ module Splunk
 
         user = options[:user] || Etc.getlogin
         password = options[:password] || cli.ask('Password: ') { |o| o.echo = '*' }
-        execution_path = options[:repo_path] || Dir.getwd
 
         pickaxe = Pickaxe.configure environment, user, password, options
         pickaxe.sync_all

--- a/lib/splunk/pickaxe/cli.rb
+++ b/lib/splunk/pickaxe/cli.rb
@@ -59,14 +59,14 @@ module Splunk
       option :user, type: :string, desc: 'The user to login to splunk with. If this is not provide it will use the current user'
       option :password, type: :string, desc: 'The password to login to splunk with. If this is not provided it will ask for a password'
       option :repo_path, type: :string, desc: 'The path to the repo. If this is not specified it is assumed you are executing from within the repo'
+      option :overwrite, type: :boolean, desc: 'Overwrite any local Splunk objects which differ from remote objects with the same name.'
       def save(environment)
         cli = HighLine.new
 
         user = options[:user] || Etc.getlogin
         password = options[:password] || cli.ask('Password: ') { |o| o.echo = '*' }
-        execution_path = options[:repo_path] || Dir.getwd
 
-        pickaxe = Pickaxe.configure environment, user, password, execution_path
+        pickaxe = Pickaxe.configure environment, user, password, options
         pickaxe.save_all
       end
     end

--- a/lib/splunk/pickaxe/cli.rb
+++ b/lib/splunk/pickaxe/cli.rb
@@ -51,7 +51,7 @@ module Splunk
         password = options[:password] || cli.ask('Password: ') { |o| o.echo = '*' }
         execution_path = options[:repo_path] || Dir.getwd
 
-        pickaxe = Pickaxe.configure environment, user, password, execution_path
+        pickaxe = Pickaxe.configure environment, user, password, options
         pickaxe.sync_all
       end
 

--- a/lib/splunk/pickaxe/client.rb
+++ b/lib/splunk/pickaxe/client.rb
@@ -12,8 +12,9 @@ module Splunk
     class Client
       attr_reader :service, :alerts, :dashboards, :eventypes, :reports, :tags, :field_extractions
 
-      def initialize(service, environment, config)
+      def initialize(service, environment, config, args)
         @service = service
+        @args = args
 
         @alerts = Alerts.new service, environment, config
         @dashboards = Dashboards.new service, environment, config
@@ -33,12 +34,14 @@ module Splunk
       end
 
       def save_all
-        @alerts.save
-        @dashboards.save
-        @eventtypes.save
-        @reports.save
+        overwrite = @args.fetch(:overwrite, false)
+
+        @alerts.save overwrite
+        @dashboards.save overwrite
+        @eventtypes.save overwrite
+        @reports.save overwrite
         # splunk-sdk doesn't seem to support iterating tags
-        @field_extractions.save
+        @field_extractions.save overwrite
       end
     end
   end

--- a/lib/splunk/pickaxe/config.rb
+++ b/lib/splunk/pickaxe/config.rb
@@ -13,7 +13,7 @@ module Splunk
         },
         'environments' => {
         },
-        'emails' => []
+        'emails' => [],
       }.freeze
 
       def self.load(execution_path)

--- a/lib/splunk/pickaxe/objects.rb
+++ b/lib/splunk/pickaxe/objects.rb
@@ -98,13 +98,15 @@ module Splunk
 
         puts "- #{splunk_entity.name}"
         if overwrite || !File.exist?(file_path)
+          overwritten = overwrite && File.exist?(file_path)
+
           File.write(file_path, {
             'name' => splunk_entity.name,
             'config' => splunk_entity_keys
                           .map { |k| { k => splunk_entity.fetch(k) } }
                           .reduce({}) { |memo, setting| memo.update(setting) }
           }.to_yaml)
-          puts overwrite ? '  Overwritten' : ' Created'
+          puts overwritten ? '  Overwritten' : '  Created'
         else
           puts '  Already exists'
         end

--- a/lib/splunk/pickaxe/objects.rb
+++ b/lib/splunk/pickaxe/objects.rb
@@ -86,27 +86,27 @@ module Splunk
         end
       end
 
-      def save
+      def save(overwrite)
         puts "Saving all #{entity_dir.capitalize}"
 
         Splunk::Collection.new(service, splunk_resource)
-                          .map { |e| save_config e }
+                          .map { |e| save_config e, overwrite }
       end
 
-      def save_config(splunk_entity)
+      def save_config(splunk_entity, overwrite)
         file_path = entity_file_path splunk_entity
 
         puts "- #{splunk_entity.name}"
-        if File.exist? file_path
-          puts '  Already exists'
-        else
+        if overwrite || !File.exist?(file_path)
           File.write(file_path, {
             'name' => splunk_entity.name,
             'config' => splunk_entity_keys
                           .map { |k| { k => splunk_entity.fetch(k) } }
                           .reduce({}) { |memo, setting| memo.update(setting) }
           }.to_yaml)
-          puts ' Created'
+          puts overwrite ? '  Overwritten' : ' Created'
+        else
+          puts '  Already exists'
         end
       end
 

--- a/lib/splunk/pickaxe/objects/dashboards.rb
+++ b/lib/splunk/pickaxe/objects/dashboards.rb
@@ -46,8 +46,10 @@ module Splunk
 
         puts "- #{splunk_entity['label']}"
         if overwrite || !File.exist?(file_path)
+          overwritten = overwrite && File.exist?(file_path)
+
           File.write(file_path, splunk_entity['eai:data'])
-          puts overwrite ? '  Overwritten' : ' Created'
+          puts overwritten ? '  Overwritten' : '  Created'
         else
           puts '  Already exists'
         end

--- a/lib/splunk/pickaxe/objects/dashboards.rb
+++ b/lib/splunk/pickaxe/objects/dashboards.rb
@@ -41,15 +41,15 @@ module Splunk
         ['.xml']
       end
 
-      def save_config(splunk_entity)
+      def save_config(splunk_entity, overwrite)
         file_path = entity_file_path splunk_entity
 
         puts "- #{splunk_entity['label']}"
-        if File.exist? file_path
-          puts '  Already exists'
-        else
+        if overwrite || !File.exist?(file_path)
           File.write(file_path, splunk_entity['eai:data'])
-          puts '  Created'
+          puts overwrite ? '  Overwritten' : ' Created'
+        else
+          puts '  Already exists'
         end
       end
     end

--- a/lib/splunk/pickaxe/objects/field_extractions.rb
+++ b/lib/splunk/pickaxe/objects/field_extractions.rb
@@ -47,11 +47,11 @@ module Splunk
         splunk_entity['value'] != splunk_config(entity)['value']
       end
 
-      def save_config(splunk_entity, override)
+      def save_config(splunk_entity, overwrite)
         file_path = entity_file_path splunk_entity
 
         puts "- #{splunk_entity.name}"
-        if override || !File.exist?(file_path)
+        if overwrite || !File.exist?(file_path)
           config = splunk_entity_keys
                    .map { |k| { k => splunk_entity.fetch(k) } }
                    .reduce({}) { |memo, setting| memo.update(setting) }
@@ -62,11 +62,12 @@ module Splunk
           config['type'] = splunk_entity.fetch('attribute').split('-').first
           config['value'].gsub!(/, /, ',')
 
+          overwritten = overwrite && File.exist?(file_path)
           File.write(file_path, {
             'name' => splunk_entity.name,
             'config' => config
           }.to_yaml)
-          puts override ? '  Overwritten' : ' Created'
+          puts overwritten ? '  Overwritten' : '  Created'
         else
           puts '  Already exists'
         end

--- a/lib/splunk/pickaxe/objects/field_extractions.rb
+++ b/lib/splunk/pickaxe/objects/field_extractions.rb
@@ -47,13 +47,11 @@ module Splunk
         splunk_entity['value'] != splunk_config(entity)['value']
       end
 
-      def save_config(splunk_entity)
+      def save_config(splunk_entity, override)
         file_path = entity_file_path splunk_entity
 
         puts "- #{splunk_entity.name}"
-        if File.exist? file_path
-          puts '  Already exists'
-        else
+        if override || !File.exist?(file_path)
           config = splunk_entity_keys
                    .map { |k| { k => splunk_entity.fetch(k) } }
                    .reduce({}) { |memo, setting| memo.update(setting) }
@@ -68,7 +66,9 @@ module Splunk
             'name' => splunk_entity.name,
             'config' => config
           }.to_yaml)
-          puts ' Created'
+          puts override ? '  Overwritten' : ' Created'
+        else
+          puts '  Already exists'
         end
       end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Splunk::Pickaxe::CLI do
-  let(:cli) { Splunk::Pickaxe::CLI.new }
+  subject { Splunk::Pickaxe::CLI.new }
   let(:file) { double('file') }
 
   context '#init' do
@@ -11,7 +11,7 @@ describe Splunk::Pickaxe::CLI do
       end
 
       allow(File).to receive(:open).with(any_args).and_return(file)
-      allow(cli).to receive(:puts).with(any_args)
+      allow(subject).to receive(:puts).with(any_args)
     end
 
     it 'creates all object directories' do
@@ -19,43 +19,63 @@ describe Splunk::Pickaxe::CLI do
         expect(Dir).to receive(:mkdir).with(clazz.const_get(:DIR))
       end
 
-      cli.init
+      subject.init
     end
   end
 
   context '#sync' do
-    let(:options) { {:user => 'my-user', :password => 'my-password', :repo_path => 'my-repo-path' } }
+    let(:options) do
+      {
+        user: 'my-user',
+        password: 'my-password',
+        repo_path: 'my-repo-path',
+      }
+    end
     let(:client) { double 'client' }
     let(:environment) { 'my-environment' }
 
     before do
-      allow(cli).to receive(:options).and_return(options)
-      allow(Splunk::Pickaxe).to receive(:configure).with(any_args).and_return(client)
+      allow(subject).to receive(:options).and_return(options)
+      allow(Splunk::Pickaxe).to receive(:configure).and_return(client)
     end
 
     it 'syncs the environment' do
-      expect(Splunk::Pickaxe).to receive(:configure).with(environment, 'my-user', 'my-password', 'my-repo-path')
+      expect(Splunk::Pickaxe).to receive(:configure).with(environment, 'my-user', 'my-password', options)
       expect(client).to receive(:sync_all)
 
-      cli.sync environment
+      subject.sync environment
     end
   end
 
   context '#save' do
-    let(:options) { {:user => 'my-user', :password => 'my-password', :repo_path => 'my-repo-path' } }
+    let(:options) do
+      {
+        user: 'my-user',
+        password: 'my-password',
+        repo_path: 'my-repo-path',
+        overwrite: false
+      }
+    end
     let(:client) { double 'client' }
     let(:environment) { 'my-environment' }
+    let(:overwrite) { false }
 
     before do
-      allow(cli).to receive(:options).and_return(options)
-      allow(Splunk::Pickaxe).to receive(:configure).with(any_args).and_return(client)
+      allow(subject).to receive(:options).and_return(options)
+      allow(client).to receive(:save_all)
+      allow(Splunk::Pickaxe).to receive(:configure).and_return(client)
     end
 
-    it 'saves the environment' do
-      expect(Splunk::Pickaxe).to receive(:configure).with(environment, 'my-user', 'my-password', 'my-repo-path')
+    it 'calls configure on pickaxe' do
+      expect(Splunk::Pickaxe).to receive(:configure).with(environment, 'my-user', 'my-password', options)
+
+      subject.save environment
+    end
+
+    it 'calls save_all on client' do
       expect(client).to receive(:save_all)
 
-      cli.save environment
+      subject.save environment
     end
   end
 end

--- a/spec/objects/dashboard_spec.rb
+++ b/spec/objects/dashboard_spec.rb
@@ -84,6 +84,7 @@ describe Splunk::Pickaxe::Dashboards do
       allow(subject).to receive(:entity_file_path).and_return(file_path)
       allow(entity).to receive(:[]).with('label').and_return('entity name')
       allow(entity).to receive(:[]).with('eai:data').and_return(entity_config)
+      allow(File).to receive(:exist?).and_return true
     end
 
     context 'when the file exists' do
@@ -91,7 +92,15 @@ describe Splunk::Pickaxe::Dashboards do
         allow(File).to receive(:exist?).and_return true
         expect(File).to_not receive(:write)
 
-        subject.save_config(entity)
+        subject.save_config(entity, false)
+      end
+
+      context 'and overwrite is passed' do
+        it 'writes the config' do
+          expect(File).to receive(:write)
+
+          subject.save_config(entity, true)
+        end
       end
     end
 
@@ -104,13 +113,13 @@ describe Splunk::Pickaxe::Dashboards do
       it 'gets eai:data from the entity' do
         expect(entity).to receive(:[]).with('eai:data').and_return({})
 
-        subject.save_config(entity)
+        subject.save_config(entity, false)
       end
 
       it 'writes eai:data to the file' do
         expect(File).to receive(:write).with(file_path, entity_config)
 
-        subject.save_config(entity)
+        subject.save_config(entity, false)
       end
     end
   end


### PR DESCRIPTION
Currently `pickaxe save [environment]` will skip Splunk objects that already exist. This PR adds an `--overwrite` option to blindly overwrite local Splunk objects with conflicting names. Currently, args are now passed down to the client so that it can store them and pass them to subcommands.