### PR TITLE
Remove unnecessary environment check (fixes #10)

### DIFF
--- a/lib/splunk/pickaxe.rb
+++ b/lib/splunk/pickaxe.rb
@@ -11,8 +11,6 @@ module Splunk
     def self.configure(environment, username, password, args)
       config = Config.load(environment, args.fetch(:repo_path, Dir.getwd))
 
-      raise "Unknown environment [#{environment}]. Expected #{config.environments.keys}" unless config.environments.key?(environment)
-
       uri = URI(config.url)
 
       puts "Connecting to splunk [#{uri}]"


### PR DESCRIPTION
Remove broken environment check when configuring `Splunk::Pickaxe`. A similar check is already happening when initializing the `Config`.
