### PR TITLE
Add local_save tag to save for only local files

### DIFF
--- a/lib/splunk/pickaxe/cli.rb
+++ b/lib/splunk/pickaxe/cli.rb
@@ -61,6 +61,7 @@ module Splunk
       option :password, type: :string, desc: 'The password to login to splunk with. If this is not provided it will ask for a password'
       option :repo_path, type: :string, desc: 'The path to the repo. If this is not specified it is assumed you are executing from within the repo'
       option :overwrite, type: :boolean, desc: 'Overwrite any local Splunk objects which differ from remote objects with the same name.'
+      option :local_save, type: :boolean, desc: 'Only retrieve local Splunk objects from remote'
       def save(environment)
         cli = HighLine.new
 

--- a/lib/splunk/pickaxe/client.rb
+++ b/lib/splunk/pickaxe/client.rb
@@ -38,14 +38,15 @@ module Splunk
 
       def save_all
         overwrite = @args.fetch(:overwrite, false)
+        local_save = @args.fetch(:local_save, false)
 
-        @alerts.save overwrite
-        @dashboards.save overwrite
-        @eventtypes.save overwrite
-        @macros.save overwrite
-        @reports.save overwrite
+        @alerts.save overwrite, local_save
+        @dashboards.save overwrite, local_save
+        @eventtypes.save overwrite, local_save
+        @macros.save overwrite, local_save
+        @reports.save overwrite, local_save
         # splunk-sdk doesn't seem to support iterating tags
-        @field_extractions.save overwrite
+        @field_extractions.save overwrite, local_save
       end
     end
   end

--- a/lib/splunk/pickaxe/objects/dashboards.rb
+++ b/lib/splunk/pickaxe/objects/dashboards.rb
@@ -44,10 +44,21 @@ module Splunk
         ['.xml']
       end
 
-      def save_config(splunk_entity, overwrite)
+      def save_config(splunk_entity, overwrite, local_save)
         file_path = entity_file_path splunk_entity
 
-        puts "- #{splunk_entity['label']}"
+        if local_save
+          if File.exist?(file_path)
+            puts "- #{splunk_entity['label']}"
+            write_to_file(file_path, overwrite, splunk_entity)
+          end
+        else
+          puts "- #{splunk_entity['label']}"
+          write_to_file(file_path, overwrite, splunk_entity)
+        end
+      end
+
+      def write_to_file(file_path, overwrite, splunk_entity)
         if overwrite || !File.exist?(file_path)
           overwritten = overwrite && File.exist?(file_path)
 

--- a/lib/splunk/pickaxe/objects/field_extractions.rb
+++ b/lib/splunk/pickaxe/objects/field_extractions.rb
@@ -47,10 +47,21 @@ module Splunk
         splunk_entity['value'] != splunk_config(entity)['value']
       end
 
-      def save_config(splunk_entity, overwrite)
+      def save_config(splunk_entity, overwrite, local_save)
         file_path = entity_file_path splunk_entity
 
-        puts "- #{splunk_entity.name}"
+        if local_save
+          if File.exist?(file_path)
+            puts "- #{splunk_entity.name}"
+            write_to_file(file_path, overwrite, splunk_entity)
+          end
+        else
+          puts "- #{splunk_entity.name}"
+          write_to_file(file_path, overwrite, splunk_entity)
+        end
+      end
+
+      def write_to_file(file_path, overwrite, splunk_entity)
         if overwrite || !File.exist?(file_path)
           config = splunk_entity_keys
                    .map { |k| { k => splunk_entity.fetch(k) } }

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -46,19 +46,19 @@ describe Splunk::Pickaxe::Client do
 
     it 'calls #save on all objects except tag' do
       classes.each do |clazz|
-        expect(class_to_double[clazz]).to receive(:save).with(false)
+        expect(class_to_double[clazz]).to receive(:save).with(false, false)
       end
 
       subject.save_all
     end
 
-    context 'when overwrite is not in args' do
+    context 'when overwrite and local_save are not in args' do
       let(:args) { { user: 'user', password: 'pass' } }
       subject { Splunk::Pickaxe::Client.new(service, environment, config, args) }
 
       it 'calls #save with false' do
         classes.each do |clazz|
-          expect(class_to_double[clazz]).to receive(:save).with(false)
+          expect(class_to_double[clazz]).to receive(:save).with(false, false)
         end
 
         subject.save_all
@@ -70,7 +70,33 @@ describe Splunk::Pickaxe::Client do
 
         it 'calls #save with overwrite\'s value' do
         classes.each do |clazz|
-          expect(class_to_double[clazz]).to receive(:save).with(true)
+          expect(class_to_double[clazz]).to receive(:save).with(true, false)
+        end
+
+        subject.save_all
+        end
+      end
+
+      context 'when local_save is in args' do
+        let(:args) { { user: 'user', password: 'pass', local_save: true } }
+        subject { Splunk::Pickaxe::Client.new(service, environment, config, args) }
+
+        it 'calls #save with overwrite\'s value' do
+        classes.each do |clazz|
+          expect(class_to_double[clazz]).to receive(:save).with(false, true)
+        end
+
+        subject.save_all
+        end
+      end
+
+      context 'when overwrite and local_save are in args' do
+        let(:args) { { user: 'user', password: 'pass', overwrite: true, local_save: true } }
+        subject { Splunk::Pickaxe::Client.new(service, environment, config, args) }
+
+        it 'calls #save with overwrite\'s value' do
+        classes.each do |clazz|
+          expect(class_to_double[clazz]).to receive(:save).with(true, true)
         end
 
         subject.save_all

--- a/spec/objects/dashboard_spec.rb
+++ b/spec/objects/dashboard_spec.rb
@@ -95,14 +95,31 @@ describe Splunk::Pickaxe::Dashboards do
         allow(File).to receive(:exist?).and_return true
         expect(File).to_not receive(:write)
 
-        subject.save_config(entity, false)
+        subject.save_config(entity, false, false)
       end
 
       context 'and overwrite is passed' do
         it 'writes the config' do
           expect(File).to receive(:write)
 
-          subject.save_config(entity, true)
+          subject.save_config(entity, true, false)
+        end
+      end
+
+      context 'and local_save is passed' do
+        it 'does not write the config' do
+          allow(File).to receive(:exist?).and_return true
+          expect(File).to_not receive(:write)
+
+          subject.save_config(entity, false, true)
+        end
+      end
+
+      context 'when overwrite and local_save are passed' do
+        it 'writes the config' do
+          expect(File).to receive(:write)
+
+          subject.save_config(entity, true, true)
         end
       end
     end
@@ -116,13 +133,21 @@ describe Splunk::Pickaxe::Dashboards do
       it 'gets eai:data from the entity' do
         expect(entity).to receive(:[]).with('eai:data').and_return({})
 
-        subject.save_config(entity, false)
+        subject.save_config(entity, false, false)
       end
 
       it 'writes eai:data to the file' do
         expect(File).to receive(:write).with(file_path, entity_config)
 
-        subject.save_config(entity, false)
+        subject.save_config(entity, false, false)
+      end
+
+      context 'and local_save is passed' do
+        it 'does not write the config' do
+          expect(File).to_not receive(:write)
+
+          subject.save_config(entity, false, true)
+        end
       end
     end
   end

--- a/spec/objects/field_extractions_spec.rb
+++ b/spec/objects/field_extractions_spec.rb
@@ -77,7 +77,7 @@ describe Splunk::Pickaxe::FieldExtractions do
         allow(File).to receive(:exist?).and_return(true)
         expect(File).to_not receive(:write)
 
-        subject.save_config(entity, false)
+        subject.save_config(entity, false, false)
       end
 
       context 'and overwrite is true' do
@@ -85,7 +85,25 @@ describe Splunk::Pickaxe::FieldExtractions do
           allow(File).to receive(:exist?).and_return(true)
           expect(File).to receive(:write)
 
-          subject.save_config(entity, true)
+          subject.save_config(entity, true, false)
+        end
+      end
+
+      context 'and local_save is passed' do
+        it 'does not write the config' do
+          allow(File).to receive(:exist?).and_return(true)
+          expect(File).to_not receive(:write)
+
+          subject.save_config(entity, false, true)
+        end
+      end
+
+      context 'when overwrite and local_save are passed' do
+        it 'writes the config' do
+          allow(File).to receive(:exist?).and_return(true)
+          expect(File).to receive(:write)
+
+          subject.save_config(entity, true, true)
         end
       end
     end
@@ -96,7 +114,7 @@ describe Splunk::Pickaxe::FieldExtractions do
           expect(entity).to receive(:fetch).with(k).and_return(entity_config[k])
         end
 
-        subject.save_config(entity, false)
+        subject.save_config(entity, false, false)
       end
 
       it 'writes transformed config to the file' do
@@ -105,7 +123,15 @@ describe Splunk::Pickaxe::FieldExtractions do
           'config' => expected_entity_config
         }.to_yaml)
 
-        subject.save_config(entity, false)
+        subject.save_config(entity, false, false)
+      end
+
+      context 'and local_save is passed' do
+        it 'does not write the config' do
+          expect(File).to_not receive(:write)
+
+          subject.save_config(entity, false, true)
+        end
       end
     end
   end

--- a/spec/objects_spec.rb
+++ b/spec/objects_spec.rb
@@ -183,6 +183,7 @@ describe Splunk::Pickaxe::Objects do
     let(:splunk_entity1) { double 'splunk_entity1' }
     let(:splunk_entity2) { double 'splunk_entity2' }
     let(:overwrite) { double 'overwrite' }
+    let(:local_save) { double 'local_save' }
 
     before do
       entity_dir = File.join(execution_path, 'my-dir')
@@ -194,17 +195,17 @@ describe Splunk::Pickaxe::Objects do
     end
 
     it 'calls save_config on every object in the collection' do
-      expect(subject).to receive(:save_config).with(splunk_entity1, false)
-      expect(subject).to receive(:save_config).with(splunk_entity2, false)
+      expect(subject).to receive(:save_config).with(splunk_entity1, false, false)
+      expect(subject).to receive(:save_config).with(splunk_entity2, false, false)
 
-      subject.save(false)
+      subject.save(false, false)
     end
 
-    it 'passes the overwrite argument to every object in the collection' do
-      expect(subject).to receive(:save_config).with(splunk_entity1, overwrite)
-      expect(subject).to receive(:save_config).with(splunk_entity2, overwrite)
+    it 'passes both the overwrite and local_save argument to every object in the collection' do
+      expect(subject).to receive(:save_config).with(splunk_entity1, overwrite, local_save)
+      expect(subject).to receive(:save_config).with(splunk_entity2, overwrite, local_save)
 
-      subject.save(overwrite)
+      subject.save(overwrite, local_save)
     end
   end
 
@@ -236,14 +237,30 @@ describe Splunk::Pickaxe::Objects do
       it 'does not write the config' do
         expect(File).to_not receive(:write)
 
-        subject.save_config(entity, false)
+        subject.save_config(entity, false, false)
       end
 
       context 'and overwrite is true' do
         it 'writes the config' do
           expect(File).to receive(:write)
 
-          subject.save_config(entity, true)
+          subject.save_config(entity, true, false)
+        end
+      end
+
+      context 'and local_save is passed' do
+        it 'does not write the config' do
+          expect(File).to_not receive(:write)
+
+          subject.save_config(entity, false, true)
+        end
+      end
+
+      context 'when overwrite and local_save are passed' do
+        it 'writes the config' do
+          expect(File).to receive(:write)
+
+          subject.save_config(entity, true, true)
         end
       end
     end
@@ -257,7 +274,7 @@ describe Splunk::Pickaxe::Objects do
       it 'gets all entity keys' do
         expect(subject).to receive(:splunk_entity_keys).and_return([])
 
-        subject.save_config(entity, false)
+        subject.save_config(entity, false, false)
       end
 
       it 'fetches every value for each entity key from the entity' do
@@ -265,7 +282,7 @@ describe Splunk::Pickaxe::Objects do
           expect(entity).to receive(:fetch).with(k)
         end
 
-        subject.save_config(entity, false)
+        subject.save_config(entity, false, false)
       end
 
       it 'combines all entity key/values and writes to yaml' do
@@ -274,7 +291,15 @@ describe Splunk::Pickaxe::Objects do
           'config' => entity_config
         }.to_yaml)
 
-        subject.save_config(entity, false)
+        subject.save_config(entity, false, false)
+      end
+
+      context 'and local_save is passed' do
+        it 'does not write the config' do
+          expect(File).to_not receive(:write)
+
+          subject.save_config(entity, false, true)
+        end
       end
     end
   end


### PR DESCRIPTION
Issue: #23 

What was changed? Why is this necessary?
* Added a `--local_save` tag to only pull Splunk objects that exist locally.
* Used with the `--overwrite` tag to update local Splunk objects:
  * `pickaxe save dev --overwrite --local_save`

How was it tested?
* Added and modified RSpec specs.
* Functional tests:
  * Pulls and updates local repository files when `--overwrite --local_save` is used.
  * Still pulls and updates all Splunk files pulled from a specific environment when the `--overwrite` tag is used.